### PR TITLE
Turning off rule enforcing "no extra parens"

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -27,8 +27,8 @@ module.exports = {
     }],
     // require parentheses for constructors
     'new-parens': 2,
-    // disallow extra parentheses
-    'no-extra-parens': 2,
+    // allow extra parentheses (so you can make your code clearer!!!!)
+    'no-extra-parens': 0,
     // disallow mixing spaces and tabs
     'no-mixed-spaces-and-tabs': 2,
     // disallow multiple spaces


### PR DESCRIPTION
Having this rule turned on requires people to write code which may be less clear, so turning it off.

@ustudio/reviewers Please review.