### PR TITLE
Adjust dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name": "eslint-config-ustudio",
   "version": "1.1.0",
   "description": "resusable ESLint config for uStudio",
-  "dependencies": {
-    "eslint-plugin-react": "^6.3.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "ava": "latest",
     "eslint": "^3.6.1",
+    "eslint-plugin-react": "^6.3.0",
     "is-plain-object": "^2.0.1"
   },
   "peerDependencies": {
-    "eslint": "^3.6.1 || ^4.0.0"
+    "eslint": "^3.6.1 || ^4.0.0",
+    "eslint-plugin-react": "^6.3.0 || ^7.0.0"
   },
   "repository": "ustudio/eslint-config-ustudio",
   "scripts": {


### PR DESCRIPTION
This moves `eslint` out of the `dependencies` and into the `devDependencies` and `peerDependencies`. It needs to be included in the `devDependencies`so that `npm test` continues to work.

I made the version requirement for the `peerDependencies` entry less restrictive (borrowed from `eslint-plugin-react`) so that `npm` doesn't output warnings when you have a newer version of `eslint` installed in your project that pulls in `eslint-config-ustudio`.

@ustudio/reviewers Please review 